### PR TITLE
Minor updates

### DIFF
--- a/src/bioontologies/obograph.py
+++ b/src/bioontologies/obograph.py
@@ -154,8 +154,8 @@ class Synonym(BaseModel, StandardizeMixin):
 
     value: str | None = Field(default=None, alias="val")
     predicate_raw: str = Field(default="hasExactSynonym", alias="pred")
-    synonym_type_raw: str = Field(
-        alias="synonymType", default="oboInOwl:SynonymType", examples=["OMO:0003000"]
+    synonym_type_raw: str | None = Field(
+        alias="synonymType", default=None, examples=["OMO:0003000"]
     )
     xrefs_raw: list[str] = Field(
         default_factory=list,

--- a/src/bioontologies/obograph.py
+++ b/src/bioontologies/obograph.py
@@ -165,7 +165,8 @@ class Synonym(BaseModel, StandardizeMixin):
 
     # Added
     predicate: Reference | None = Field(
-        default=None, examples=[Reference(prefix="", identifier="hasExactSynonym")]
+        default=None,
+        examples=[Reference(prefix="oboInOwl", identifier="hasExactSynonym")],
     )
     synonym_type: Reference | None = Field(
         default=None, examples=[Reference(prefix="OMO", identifier="0003000")]

--- a/src/bioontologies/obograph.py
+++ b/src/bioontologies/obograph.py
@@ -627,6 +627,7 @@ class Graph(BaseModel, StandardizeMixin):
                 "desc": "standardizing nodes" if not prefix else f"[{prefix}] standardizing nodes",
                 "unit_scale": True,
                 "disable": not use_tqdm,
+                "leave": False,
             }
             if tqdm_kwargs:
                 _node_tqdm_kwargs.update(tqdm_kwargs)

--- a/src/bioontologies/obograph.py
+++ b/src/bioontologies/obograph.py
@@ -26,8 +26,6 @@ from .constants import CANONICAL, IRI_TO_PREFIX
 from .relations import get_normalized_label, ground_relation, label_norm
 
 __all__ = [
-    "OBO_SYNONYM_TO_OIO",
-    "OIO_TO_REFERENCE",
     "Definition",
     "Edge",
     "Graph",
@@ -149,24 +147,6 @@ class Xref(BaseModel, StandardizeMixin):
             predicate=predicate,
             standardized=True,
         )
-
-
-#: Mapping from shorthand for predicates to qualified references
-OIO_TO_REFERENCE: Mapping[str, Reference] = {
-    "hasExactSynonym": Reference(prefix="oboInOwl", identifier="hasExactSynonym"),
-    "hasBroadSynonym": Reference(prefix="oboInOwl", identifier="hasBroadSynonym"),
-    "hasNarrowSynonym": Reference(prefix="oboInOwl", identifier="hasNarrowSynonym"),
-    "hasRelatedSynonym": Reference(prefix="oboInOwl", identifier="hasRelatedSynonym"),
-}
-
-#: A mapping from OBO flat file format internal synonym types to OBO in OWL vocabulary
-#: identifiers. See https://owlcollab.github.io/oboformat/doc/GO.format.obo-1_4.html
-OBO_SYNONYM_TO_OIO = {
-    "EXACT": "hasExactSynonym",
-    "BROAD": "hasBroadSynonym",
-    "NARROW": "hasNarrowSynonym",
-    "RELATED": "hasRelatedSynonym",
-}
 
 
 class Synonym(BaseModel, StandardizeMixin):

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -355,7 +355,7 @@ def convert_to_obograph(
                 raise ValueError(f"{input_path} graphs missing IDs: {missing}")
 
         correct_raw_json(graph_document_raw)
-        graph_document = GraphDocument.parse_obj(graph_document_raw)
+        graph_document = GraphDocument.model_validate(graph_document_raw)
         return ParseResults(
             graph_document=graph_document,
             messages=messages,

--- a/src/bioontologies/version.py
+++ b/src/bioontologies/version.py
@@ -30,7 +30,7 @@ def get_git_hash() -> str:
             return ret.strip().decode("utf-8")[:8]
 
 
-def get_version(with_git_hash: bool = False):
+def get_version(with_git_hash: bool = False) -> str:
     """Get the :mod:`bioontologies` version string, including a git hash."""
     return f"{VERSION}-{get_git_hash()}" if with_git_hash else VERSION
 


### PR DESCRIPTION
- Add missing typing
- Use modern pydantic model_validate function
- Remove deprecated oboInOwl objects that are now in `curies.vocabulary`
- Allow synonym type to be none instead of making the oboInOwl:SynonymType as default