### PR TITLE
Raise more informative ROBOT error

### DIFF
--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -433,6 +433,17 @@ class RobotError(Exception):
         output: str | None = None,
         preview_length: int = 500,
     ):
+        """Initialize RobotError
+
+        :param command: The command that was executed and failed
+        :param returncode: The exit code returned by the command
+        :param output: The stdout/stderr output from the command execution
+        :param preview_length: Maximum number of characters to include in the
+            error message preview. Default is 500 characters.
+
+        The error message will contain the command, return code, and a preview
+        of the output truncated to preview_length characters.
+        """
         self.command = command
         self.returncode = returncode
         self.output = output

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -24,6 +24,7 @@ from .obograph import Graph, GraphDocument
 
 __all__ = [
     "ParseResults",
+    "ROBOTError",
     "convert",
     "convert_to_obograph",
     "convert_to_obograph_local",
@@ -92,7 +93,9 @@ def call_robot(args: list[str]) -> str:
             cwd=os.path.dirname(__file__),
         )
     except subprocess.CalledProcessError as e:
-        raise RobotError(command=e.cmd, returncode=e.returncode, output=e.output.decode()) from None
+        raise ROBOTError(
+            command=e.cmd, return_code=e.returncode, output=e.output.decode()
+        ) from None
     return ret.decode()
 
 
@@ -443,41 +446,40 @@ def _path_context(path: None | str | Path, name: str = "output.json"):
             yield Path(directory).joinpath(name)
 
 
-class RobotError(Exception):
-    """Custom error for Robot command failures that includes output preview."""
+class ROBOTError(Exception):
+    """Custom error for ROBOT command failures that includes output preview."""
 
     def __init__(
         self,
         command: list[str],
-        returncode: int,
+        return_code: int,
         output: str | None = None,
         preview_length: int = 500,
-    ):
-        """Initialize RobotError.
+    ) -> None:
+        """Initialize a wrapper around a ROBOT exception.
 
         :param command: The command that was executed and failed
-        :param returncode: The exit code returned by the command
+        :param return_code: The exit code returned by the command
         :param output: The stdout/stderr output from the command execution
-        :param preview_length: Maximum number of characters to include in the
+        :param preview_length:
+            Maximum number of characters to include in the
             error message preview. Default is 500 characters.
 
         The error message will contain the command, return code, and a preview
         of the output truncated to preview_length characters.
         """
         self.command = command
-        self.returncode = returncode
+        self.return_code = return_code
         self.output = output
         self.preview_length = preview_length
 
         # Create the error message
-        command_str = str(command)
-        output_preview = (
-            output[:preview_length] + "..." if output and len(output) > preview_length else output
-        )
+        command_str = " ".join(command)
+        output_preview = textwrap.indent(textwrap.shorten(output, preview_length), "  ")
 
         message = (
-            f"Command {command_str} returned non-zero exit status {returncode}. \n"
-            f"Output: {output_preview}"
+            f"Command `{command_str}` returned non-zero exit status {return_code}.\n\n"
+            f"Output:\n\n{output_preview}"
         )
 
         super().__init__(message)

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -94,8 +94,11 @@ def call_robot(args: list[str]) -> str:
         )
     except subprocess.CalledProcessError as e:
         raise ROBOTError(
-            command=e.cmd, return_code=e.returncode, output=e.output.decode()
+            command=e.cmd,
+            return_code=e.returncode,
+            output=e.output.decode() if e.output is not None else None,
         ) from None
+
     return ret.decode()
 
 

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import check_output
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 
 import bioregistry
 import pystow
@@ -427,9 +427,9 @@ class RobotError(Exception):
 
     def __init__(
         self,
-        command: List[str],
+        command: list[str],
         returncode: int,
-        output: Optional[str] = None,
+        output: str | None = None,
         preview_length: int = 500
     ):
         self.command = command
@@ -439,7 +439,10 @@ class RobotError(Exception):
 
         # Create the error message
         command_str = str(command)
-        output_preview = output[:preview_length] + "..." if output and len(output) > preview_length else output
+        output_preview = (
+            output[:preview_length] + "..." if output and len(output) > preview_length
+            else output
+        )
 
         message = (
             f"Command {command_str} returned non-zero exit status {returncode}. \n"

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -473,15 +473,12 @@ class ROBOTError(Exception):
         """
         self.command = command
         self.return_code = return_code
-        self.output = output
+        self.output = output or "<no output>"
         self.preview_length = preview_length
 
         # Create the error message
         command_str = " ".join(command)
-        if output is None:
-            output_preview = "<no output>"
-        else:
-            output_preview = textwrap.indent(textwrap.shorten(output, preview_length), "  ")
+        output_preview = textwrap.indent(textwrap.shorten(self.output, preview_length), "  ")
 
         message = (
             f"Command `{command_str}` returned non-zero exit status {return_code}.\n\n"

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -433,7 +433,7 @@ class RobotError(Exception):
         output: str | None = None,
         preview_length: int = 500,
     ):
-        """Initialize RobotError
+        """Initialize RobotError.
 
         :param command: The command that was executed and failed
         :param returncode: The exit code returned by the command

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -9,6 +9,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import textwrap
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -571,6 +571,7 @@ def convert(
         args.extend(("--format", fmt))
     if debug:
         args.append("-vvv")
+
     return call_robot(args)
 
 

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -422,6 +422,7 @@ def _path_context(path: None | str | Path, name: str = "output.json"):
         with tempfile.TemporaryDirectory() as directory:
             yield Path(directory).joinpath(name)
 
+
 class RobotError(Exception):
     """Custom error for Robot command failures that includes output preview."""
 
@@ -430,7 +431,7 @@ class RobotError(Exception):
         command: list[str],
         returncode: int,
         output: str | None = None,
-        preview_length: int = 500
+        preview_length: int = 500,
     ):
         self.command = command
         self.returncode = returncode
@@ -440,8 +441,7 @@ class RobotError(Exception):
         # Create the error message
         command_str = str(command)
         output_preview = (
-            output[:preview_length] + "..." if output and len(output) > preview_length
-            else output
+            output[:preview_length] + "..." if output and len(output) > preview_length else output
         )
 
         message = (
@@ -450,7 +450,6 @@ class RobotError(Exception):
         )
 
         super().__init__(message)
-
 
 
 def convert(
@@ -540,11 +539,7 @@ def convert(
             cwd=os.path.dirname(__file__),
         )
     except subprocess.CalledProcessError as e:
-        raise RobotError(
-            command=e.cmd,
-            returncode=e.returncode,
-            output=e.output.decode()
-        ) from None
+        raise RobotError(command=e.cmd, returncode=e.returncode, output=e.output.decode()) from None
     return ret.decode()
 
 

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -96,7 +96,6 @@ def call_robot(args: list[str]) -> str:
     return ret.decode()
 
 
-
 @dataclass
 class ParseResults:
     """A dataclass containing an OBO Graph JSON and text output from ROBOT."""

--- a/src/bioontologies/robot.py
+++ b/src/bioontologies/robot.py
@@ -60,7 +60,7 @@ def is_available() -> bool:
         return False
 
     try:
-        check_output(["java", "--help"])  # noqa:S607,S603
+        check_output(["java", "--help"])  # noqa: S607
     except Exception:
         logger.error(
             "java --help failed - this means the java runtime environment (JRE) "
@@ -475,7 +475,10 @@ class ROBOTError(Exception):
 
         # Create the error message
         command_str = " ".join(command)
-        output_preview = textwrap.indent(textwrap.shorten(output, preview_length), "  ")
+        if output is None:
+            output_preview = "<no output>"
+        else:
+            output_preview = textwrap.indent(textwrap.shorten(output, preview_length), "  ")
 
         message = (
             f"Command `{command_str}` returned non-zero exit status {return_code}.\n\n"


### PR DESCRIPTION
I've often been confused by the error shown if Robot conversion fails since it doesn't show the actual output from Robot so the reason for the error is unclear:

```python
CalledProcessError: Command '['java', '-jar', '/Users/ben/.data/robot/1.9.7/robot.jar', 'merge', '-i',
 '/Users/ben/.data/pyobo/raw/bao/bao_complete.owl', 'convert', '-o', 
'/Users/ben/.data/pyobo/raw/bao/bao_complete.obo']' returned non-zero exit status 1.
```

There are two challenges: subprocess.CalledProcessError doesn't surface the output by default and the output can be very long which if fully displayed would be disruptive. So this PR adds a custom RobotError class which is raised instead of subprocess.CalledProcessError and creates a nicer and easier-to-customize output:

```python
RobotError: Command ['java', '-jar', '/Users/ben/.data/robot/1.9.7/robot.jar', 'merge', '-i', 
'/Users/ben/.data/pyobo/raw/bao/bao_complete.owl', 'convert', '-o', 
'/Users/ben/.data/pyobo/raw/bao/bao_complete.obo'] returned non-zero exit status 1.
Output: OBO STRUCTURE ERROR Ontology does not conform to OBO structure rules:
multiple name tags not allowed. in frame:Frame(null ontology( http://www.bioassayontology.org/
bao/bao_complete.owl)data-version( http://www.bioassayontology.org/bao/bao_complete.owl)
property_value( dc:date March20, 2025 xsd:string)property_value( dc:license 
https://creativecommons.org/licenses/by-sa/4.0/)remark( Contact: Stephan Schurer stephan 
dot schurer at med dot miami dot edu)remark( Created by: Caty Chung, Nicolette Ross...
```
by default showing up to 500 characters of the actual Robot error.

Fixes #10 though taking a different approach to the one suggested there.